### PR TITLE
Updated workflow trigger conditions with support to additional JDK distributions

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -46,7 +46,8 @@ jobs:
                 tests-pattern: ['rules-reviewed/[a-d]', 'rules-reviewed/eap6', 'rules-reviewed/eap7', 'rules-reviewed/eap8', 'rules-reviewed/eapxp', 'rules-reviewed/\(\(e[^a]\)\|[f-s]\)', 'rules-reviewed/technology-usage/tests/[0-9,a-i]', 'rules-reviewed/technology-usage/tests/[j-z]', 'rules-reviewed/[u-z]', 'rules-generated/']
                 java-version: [ 11, 17 ]
         steps:
-            - uses: actions/checkout@v3
+            - name: Checkout windup-rulesets
+              uses: actions/checkout@v3
             - name: Set up MS Build of OpenJDK
               uses: actions/setup-java@v3
               with:
@@ -72,7 +73,8 @@ jobs:
             matrix:
                 java-version: [ 11, 17 ]
         steps:
-            - uses: actions/checkout@v3
+            - name: Checkout windup-rulesets
+              uses: actions/checkout@v3
             - name: Set up MS Build of OpenJDK 11
               uses: actions/setup-java@v3
               with:

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,83 +1,91 @@
+# PR-build-CI.yaml
+# This yaml script will trigger when a PR is created on to the main branch - will ensure that the repo is built successfully with all the dependencies.
+## Platform - Ubuntu
 name: Azure WindUp Rulesets PR builder
 
+env:
+    JAVA_DISTRIBUTION: 'microsoft'
+
 on:
-  workflow_dispatch:
-  pull_request:
-    branches:
-      - master
-      - 'releases/**'
+    workflow_dispatch:
+    pull_request:
+        branches:
+            - main
 
 jobs:
+    windup-build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout JEG windup Azdo repo
+              run: 'git clone https://${{secrets.USER}}:${{secrets.GH}}@devdiv.visualstudio.com/DefaultCollection/DevDiv/_git/JEG-windup'
+              shell: bash
 
-  windup-build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout WindUp upstream repo
-        uses: actions/checkout@v3
-        with:
-          repository: windup/windup
-          ref: ${{ github.base_ref }}
-      - name: Set up MS Build of OpenJDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'microsoft'
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-            path: ~/.m2/repository
-            key: ${{ runner.os }}-maven-azure-windup-build-${{ github.sha }}
-            restore-keys:
-                ${{ runner.os }}-maven-azure-windup-build
-      - name: Build WindUp
-        run: ./mvnw -B clean install -DskipTests
+            - name: Set up MS Build of OpenJDK 11
+              uses: actions/setup-java@v3
+              with:
+                  java-version: '11'
+                  distribution: ${{env.JAVA_DISTRIBUTION}}
+            - name: Cache local Maven repository
+              uses: actions/cache@v3
+              with:
+                  path: ~/.m2/repository
+                  key: ${{ runner.os }}-maven-azure-windup-build-${{ github.sha }}
+                  restore-keys:
+                      ${{ runner.os }}-maven-azure-windup-build
 
-  windup-rules-test:
-    runs-on: ubuntu-latest
-    needs: [windup-build]
-    strategy:
-      fail-fast: false
-      matrix:
-        tests-pattern: [ 'rules-reviewed/azure' ]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up MS Build of OpenJDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'microsoft'
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-            path: ~/.m2/repository
-            key: ${{ runner.os }}-maven-azure-windup-rulesets-build-${{ github.sha }}
-            restore-keys: |
-                ${{ runner.os }}-maven-azure-windup-build-${{ github.sha }}
-      - name: Build
-        run: ./mvnw -B clean install -DskipTests
-      - name: Test
-        run: ./mvnw -B test -f rules/ -DrunTestsMatching=${{ matrix.tests-pattern }} -Dtest=WindupRulesTest
-
-  windup-rules-links-test:
-    runs-on: ubuntu-latest
-    needs: [windup-build]
-    strategy:
-        fail-fast: false
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up MS Build of OpenJDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'microsoft'
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-            path: ~/.m2/repository
-            key: ${{ runner.os }}-maven-azure-windup-rulesets-build-${{ github.sha }}
-            restore-keys: |
-                ${{ runner.os }}-maven-azure-windup-build-${{ github.sha }}
-      - name: Build
-        run: ./mvnw -B clean install -DskipTests
-      - name: Test
-        run: ./mvnw -B test -f rules/ -Dtest=WindupRulesLinksTest
+            - name: Build WindUp
+              run: mvn -B clean install -DskipTests
+              working-directory: JEG-windup
+    
+    windup-rules-test:
+        runs-on: ubuntu-latest
+        needs: [windup-build]
+        strategy:
+            fail-fast: false
+            matrix:
+                tests-pattern: ['rules-reviewed/[a-d]', 'rules-reviewed/eap6', 'rules-reviewed/eap7', 'rules-reviewed/eap8', 'rules-reviewed/eapxp', 'rules-reviewed/\(\(e[^a]\)\|[f-s]\)', 'rules-reviewed/technology-usage/tests/[0-9,a-i]', 'rules-reviewed/technology-usage/tests/[j-z]', 'rules-reviewed/[u-z]', 'rules-generated/']
+                java-version: [ 11, 17 ]
+        steps:
+            - uses: actions/checkout@v3
+            - name: Set up MS Build of OpenJDK
+              uses: actions/setup-java@v3
+              with:
+                  java-version: ${{ matrix.java-version }}
+                  distribution: ${{ env.JAVA_DISTRIBUTION }}
+            - name: Cache local Maven repository
+              uses: actions/cache@v3
+              with:
+                  path: ~/.m2/repository
+                  key: ${{ runner.os }}-maven-azure-windup-rulesets-build-${{ github.sha }}
+                  restore-keys: |
+                      ${{ runner.os }}-maven-azure-windup-build-${{ github.sha }}
+            - name: Build
+              run: ./mvnw -B clean install -DskipTests
+            - name: Test
+              run: ./mvnw -B test -f rules/ -DrunTestsMatching=${{ matrix.tests-pattern }} -Dtest=WindupRulesTest
+    
+    windup-rules-links-test:
+        runs-on: ubuntu-latest
+        needs: [windup-build]
+        strategy:
+            fail-fast: false
+            matrix:
+                java-version: [ 11, 17 ]
+        steps:
+            - uses: actions/checkout@v3
+            - name: Set up MS Build of OpenJDK 11
+              uses: actions/setup-java@v3
+              with:
+                  java-version: ${{ matrix.java-version }}
+                  distribution: ${{ env.JAVA_DISTRIBUTION }}
+            - name: Cache local Maven repository
+              uses: actions/cache@v3
+              with:
+                  path: ~/.m2/repository
+                  key: ${{ runner.os }}-maven-azure-windup-rulesets-build-${{ github.sha }}
+                  restore-keys: |
+                      ${{ runner.os }}-maven-azure-windup-build-${{ github.sha }}
+            - name: Build
+              run: ./mvnw -B clean install -DskipTests
+            - name: Test
+              run: ./mvnw -B test -f rules/ -Dtest=WindupRulesLinksTest


### PR DESCRIPTION
**Description:**

This PR contains changes to the PR builder github workflow file. The changes are: 
- A build and test action will now trigger if a PR is created from main branch (Internal Dev branch for adding Azure rulesets) to ensure there is no regressions
- Added additional JDK versions: [11, 17]
- Refactored code 
-  Updated Windup build repo from upstream to internal JEG-windup repo: https://devdiv.visualstudio.com/DevDiv/_git/JEG-windup 

**Test Run:** 
https://github.com/kthatipally/windup-rulesets/actions/runs/5094352421/jobs/9158055852