### PR TITLE
Init Azure target transformer

### DIFF
--- a/rules/rules-reviewed/azure/azure-aks.windup.technologytransformer.xml
+++ b/rules/rules-reviewed/azure/azure-aks.windup.technologytransformer.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<technology-reference-transfomers xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <transform>
+        <sourceTechnology id="azure-aks"/>
+        <targetTechnology id="openjdk" versionRange="[11]"/>
+    </transform>
+    <transform>
+        <sourceTechnology id="azure-aks"/>
+        <targetTechnology id="cloud-readiness"/>
+    </transform>
+    <transform>
+        <sourceTechnology id="azure-aks"/>
+        <targetTechnology id="linux"/>
+    </transform>
+</technology-reference-transfomers>

--- a/rules/rules-reviewed/azure/azure-aks.windup.technologytransformer.xml
+++ b/rules/rules-reviewed/azure/azure-aks.windup.technologytransformer.xml
@@ -2,10 +2,6 @@
 <technology-reference-transfomers xmlns="http://windup.jboss.org/schema/jboss-ruleset">
     <transform>
         <sourceTechnology id="azure-aks"/>
-        <targetTechnology id="openjdk" versionRange="[11]"/>
-    </transform>
-    <transform>
-        <sourceTechnology id="azure-aks"/>
         <targetTechnology id="cloud-readiness"/>
     </transform>
     <transform>

--- a/rules/rules-reviewed/azure/azure-appservice.windup.technologytransformer.xml
+++ b/rules/rules-reviewed/azure/azure-appservice.windup.technologytransformer.xml
@@ -2,10 +2,6 @@
 <technology-reference-transfomers xmlns="http://windup.jboss.org/schema/jboss-ruleset">
     <transform>
         <sourceTechnology id="azure-appservice"/>
-        <targetTechnology id="openjdk" versionRange="[11]"/>
-    </transform>
-    <transform>
-        <sourceTechnology id="azure-appservice"/>
         <targetTechnology id="cloud-readiness"/>
     </transform>
     <transform>

--- a/rules/rules-reviewed/azure/azure-appservice.windup.technologytransformer.xml
+++ b/rules/rules-reviewed/azure/azure-appservice.windup.technologytransformer.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<technology-reference-transfomers xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <transform>
+        <sourceTechnology id="azure-appservice"/>
+        <targetTechnology id="openjdk" versionRange="[11]"/>
+    </transform>
+    <transform>
+        <sourceTechnology id="azure-appservice"/>
+        <targetTechnology id="cloud-readiness"/>
+    </transform>
+    <transform>
+        <sourceTechnology id="azure-appservice"/>
+        <targetTechnology id="linux"/>
+    </transform>
+</technology-reference-transfomers>

--- a/rules/rules-reviewed/azure/azure-container-apps.windup.technologytransformer.xml
+++ b/rules/rules-reviewed/azure/azure-container-apps.windup.technologytransformer.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<technology-reference-transfomers xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <transform>
+        <sourceTechnology id="azure-container-apps"/>
+        <targetTechnology id="openjdk" versionRange="[11]"/>
+    </transform>
+    <transform>
+        <sourceTechnology id="azure-container-apps"/>
+        <targetTechnology id="cloud-readiness"/>
+    </transform>
+    <transform>
+        <sourceTechnology id="azure-container-apps"/>
+        <targetTechnology id="linux"/>
+    </transform>
+</technology-reference-transfomers>

--- a/rules/rules-reviewed/azure/azure-container-apps.windup.technologytransformer.xml
+++ b/rules/rules-reviewed/azure/azure-container-apps.windup.technologytransformer.xml
@@ -2,10 +2,6 @@
 <technology-reference-transfomers xmlns="http://windup.jboss.org/schema/jboss-ruleset">
     <transform>
         <sourceTechnology id="azure-container-apps"/>
-        <targetTechnology id="openjdk" versionRange="[11]"/>
-    </transform>
-    <transform>
-        <sourceTechnology id="azure-container-apps"/>
         <targetTechnology id="cloud-readiness"/>
     </transform>
     <transform>

--- a/rules/rules-reviewed/azure/azure-spring-apps.windup.technologytransformer.xml
+++ b/rules/rules-reviewed/azure/azure-spring-apps.windup.technologytransformer.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<technology-reference-transfomers xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <transform>
+        <sourceTechnology id="azure-spring-apps"/>
+        <targetTechnology id="openjdk" versionRange="[11]"/>
+    </transform>
+    <transform>
+        <sourceTechnology id="azure-spring-apps"/>
+        <targetTechnology id="cloud-readiness"/>
+    </transform>
+    <transform>
+        <sourceTechnology id="azure-spring-apps"/>
+        <targetTechnology id="linux"/>
+    </transform>
+</technology-reference-transfomers>

--- a/rules/rules-reviewed/azure/azure-spring-apps.windup.technologytransformer.xml
+++ b/rules/rules-reviewed/azure/azure-spring-apps.windup.technologytransformer.xml
@@ -2,10 +2,6 @@
 <technology-reference-transfomers xmlns="http://windup.jboss.org/schema/jboss-ruleset">
     <transform>
         <sourceTechnology id="azure-spring-apps"/>
-        <targetTechnology id="openjdk" versionRange="[11]"/>
-    </transform>
-    <transform>
-        <sourceTechnology id="azure-spring-apps"/>
         <targetTechnology id="cloud-readiness"/>
     </transform>
     <transform>


### PR DESCRIPTION
@mrizzi I am trying to implement https://github.com/Azure/windup-rulesets/issues/37 (enabling `cloud-readiness` and `linux` and `openjdk` rules when an Azure target is selected). Basically I am adding several targets:

```xml
<technology-reference-transfomers xmlns="http://windup.jboss.org/schema/jboss-ruleset">
    <transform>
        <sourceTechnology id="azure-spring-apps"/>
        <targetTechnology id="openjdk" versionRange="[11]"/>
    </transform>
    <transform>
        <sourceTechnology id="azure-spring-apps"/>
        <targetTechnology id="cloud-readiness"/>
    </transform>
    <transform>
        <sourceTechnology id="azure-spring-apps"/>
        <targetTechnology id="linux"/>
    </transform>
</technology-reference-transfomers>
```

When I test all the Azure rules (`mvn clean test -DrunTestsMatching=azure`), the overriden rule fails:

```
Failed tests: 
  WindupRulesTest.testWindupRules:155 
        Error with test: database-01700-test
        Cause: (Rule: database-01700-test) Assertion failed: PostgreSQL database found hint was not found!
``` 

This message comes from `technology-usage/tests/database-target-discovery.windup.test.xml` which has a `<target>discovery</target>`. So I've added the `discovery` target to the transformer but it does not work either.

```xml
    <transform>
        <sourceTechnology id="azure-spring-apps"/>
        <targetTechnology id="discovery"/>
    </transform>
```
