### PR TITLE
Overrides the existing SAML/OpenSML security rule

### DIFF
--- a/rules/rules-overridden-azure/technology-usage/security.windup.xml
+++ b/rules/rules-overridden-azure/technology-usage/security.windup.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<ruleset id="security"
+         xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset provides analysis of Java security libraries.
+            This ruleset overrides the rules/rules-reviewed/technology-usage/security.windup.xml ruleset.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final"/>
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final"/>
+        </dependencies>
+        <targetTechnology id="azure-spring-apps"/>
+        <targetTechnology id="azure-appservice"/>
+        <targetTechnology id="azure-aks"/>
+        <targetTechnology id="azure-container-apps"/>
+        <overrideRules>true</overrideRules>
+    </metadata>
+    <rules>
+        <rule id="security-01900">
+            <when>
+                <file filename="{*}saml{*}.jar"/>
+            </when>
+            <perform>
+                <hint title="Embedded library - SAML" category-id="information" effort="0">
+                    <message>
+                        The application embeds a SAML library. The Microsoft identity platform uses SAML and other protocols to enable applications to provide a Single Sign-On experience.
+
+                        By migrating your SSO implementation to Azure AD with SAML, you leverage the capabilities of Azure AD for managing identities and enabling secure SSO across your applications. Azure AD offers features like multi-factor authentication, conditional access policies, and seamless integration with various SaaS applications, providing a robust and scalable solution for identity and access management in the cloud.
+                    </message>
+                    <link title="SAML authentication with Azure Active Directory" href="https://learn.microsoft.com/azure/active-directory/fundamentals/auth-saml"/>
+                    <link title="How the Microsoft identity platform uses the SAML protocol" href="https://learn.microsoft.com/azure/active-directory/develop/saml-protocol-reference"/>
+                    <link title="Microsoft identity platform documentation" href="https://learn.microsoft.com/azure/active-directory/develop"/>
+                    <link title="Azure Active Directory documentation" href="https://learn.microsoft.com/en-us/azure/active-directory"/>
+                </hint>
+                <technology-tag level="INFORMATIONAL">SAML</technology-tag>
+            </perform>
+        </rule>
+        <rule id="security-02800">
+            <when>
+                <file filename="{*}opensaml{*}.jar"/>
+            </when>
+            <perform>
+                <hint title="Embedded library - OpenSAML" category-id="information" effort="0">
+                    <message>
+                        The application embeds an OpenSAML library. The Microsoft identity platform uses SAML and other protocols to enable applications to provide a Single Sign-On experience.
+
+                        By migrating your SSO implementation to Azure AD with SAML, you leverage the capabilities of Azure AD for managing identities and enabling secure SSO across your applications. Azure AD offers features like multi-factor authentication, conditional access policies, and seamless integration with various SaaS applications, providing a robust and scalable solution for identity and access management in the cloud.
+                    </message>
+                    <link title="SAML authentication with Azure Active Directory" href="https://learn.microsoft.com/azure/active-directory/fundamentals/auth-saml"/>
+                    <link title="How the Microsoft identity platform uses the SAML protocol" href="https://learn.microsoft.com/azure/active-directory/develop/saml-protocol-reference"/>
+                    <link title="Microsoft identity platform documentation" href="https://learn.microsoft.com/azure/active-directory/develop"/>
+                    <link title="Azure Active Directory documentation" href="https://learn.microsoft.com/en-us/azure/active-directory"/>
+                </hint>
+                <technology-tag level="INFORMATIONAL">OpenSAML</technology-tag>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules/rules-overridden-azure/technology-usage/tests/security-target-azure-appservice.windup.test.xml
+++ b/rules/rules-overridden-azure/technology-usage/tests/security-target-azure-appservice.windup.test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruletest id="security-azure-appservice-test"
+          xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>../../../rules-reviewed/technology-usage/tests/data/security</testDataPath>
+    <rulePath>../../../rules-reviewed/technology-usage/security.windup.xml</rulePath>
+    <rulePath>../../../rules-reviewed/technology-usage/security-technology-usage.windup.xml</rulePath>
+    <rulePath>../security.windup.xml</rulePath>
+    <target>azure-appservice</target>
+    <ruleset>
+        <rules>
+            <rule id="security-azure-appservice-01900-test">
+                <when>
+                    <not>
+                        <iterable-filter size="2">
+                            <hint-exists message="The application embeds a SAML library. The Microsoft identity platform uses SAML and other protocols to enable applications to provide a Single Sign-On experience."/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="SAML hint for Azure was not found!"/>
+                </perform>
+            </rule>
+            <rule id="security-azure-appservice-02800-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="The application embeds an OpenSAML library. The Microsoft identity platform uses SAML and other protocols to enable applications to provide a Single Sign-On experience."/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="OpenSAML hint for Azure was not found!"/>
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>

--- a/rules/rules-overridden-azure/technology-usage/tests/security-target-discovery.windup.test.xml
+++ b/rules/rules-overridden-azure/technology-usage/tests/security-target-discovery.windup.test.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruletest id="security-discovery-test"
+          xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>../../../rules-reviewed/technology-usage/tests/data/security</testDataPath>
+    <rulePath>../../../rules-reviewed/technology-usage/security.windup.xml</rulePath>
+    <rulePath>../../../rules-reviewed/technology-usage/security-technology-usage.windup.xml</rulePath>
+    <rulePath>../security.windup.xml</rulePath>
+    <target>discovery</target>
+    <ruleset>
+        <rules>
+            <rule id="security-discovery-01900-test">
+                <when>
+                    <not>
+                        <classification-exists classification="Embedded library - SAML"/>
+                        <technology-tag-exists technology-tag="SAML"/>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Expected data not found for rule security-01900"/>
+                </perform>
+            </rule>
+            <rule id="security-discovery-02800-test">
+                <when>
+                    <not>
+                        <classification-exists classification="Embedded library - OpenSAML"/>
+                        <technology-tag-exists technology-tag="OpenSAML"/>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Expected data not found for rule security-02800"/>
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>


### PR DESCRIPTION
The Link tests fail but it's not due to our rules. I've created a JIRA so it can be fixed on WindUp: https://issues.redhat.com/browse/WINDUP-3959