### PR TITLE
Update the linux pool

### DIFF
--- a/.devops/ci.yml
+++ b/.devops/ci.yml
@@ -49,7 +49,7 @@ extends:
         - job: build
           displayName: Build appcat-rulesets
           pool:
-              name: JEG-ubuntu20.04-x64-EO
+              name: JEG-ubuntu20.04-x64-release
               os: linux
           steps:
             - checkout: self


### PR DESCRIPTION
The infrastructure team removed a few pools which were not in use (or low enough in use to be removed). This change updates to a proper pool that is in use and is the same version of Ubuntu.